### PR TITLE
Improve task creation form layout

### DIFF
--- a/src/pages/CreateTask/steps/Step1Basics.tsx
+++ b/src/pages/CreateTask/steps/Step1Basics.tsx
@@ -1,5 +1,5 @@
 //   steps/Step1Basics.tsx  (ejemplo)
-import { Form, Input, Select, Button } from "antd";
+import { Form, Input, Select, Button, Row, Col, InputNumber } from "antd";
 import { useNavigate } from "react-router-dom";
 import { useWizard } from "../TaskDraftContext";
 
@@ -11,21 +11,63 @@ export default function Step1Basics() {
     <Form
       layout="vertical"
       initialValues={draft}
-      onFinish={(vals)=>{ setDraft({...draft, ...vals}); nav("../step-2"); }}
+      onFinish={(vals) => {
+        setDraft({ ...draft, ...vals });
+        nav("../step-2");
+      }}
     >
-      <Form.Item name="title" label="Título" rules={[{required:true}]}>
-        <Input/>
+      <h2 className="text-xl font-semibold mb-4">Paso 1: Datos básicos</h2>
+
+      <Row gutter={16}>
+        <Col span={12}>
+          <Form.Item
+            name="title"
+            label="Título"
+            rules={[{ required: true, message: 'Introduce un título' }]}
+          >
+            <Input placeholder="Ej.: Reparar gotera" />
+          </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item
+            name="category"
+            label="Categoría"
+            rules={[{ required: true, message: 'Selecciona una categoría' }]}
+          >
+            <Select
+              placeholder="Categoría"
+              options={["Eventos", "Logística"].map((v) => ({ value: v, label: v }))}
+            />
+          </Form.Item>
+        </Col>
+      </Row>
+
+      <Row gutter={16}>
+        <Col span={12}>
+          <Form.Item
+            name="rate"
+            label="Tarifa €/h"
+            rules={[{ required: true, message: 'Introduce una tarifa' }]}
+          >
+            <InputNumber min={0} style={{ width: '100%' }} placeholder="15" />
+          </Form.Item>
+        </Col>
+        <Col span={12}>
+          <Form.Item
+            name="duration"
+            label="Duración"
+            rules={[{ required: true, message: 'Introduce la duración' }]}
+          >
+            <Input placeholder="4 h, 1 día…" />
+          </Form.Item>
+        </Col>
+      </Row>
+
+      <Form.Item>
+        <Button type="primary" htmlType="submit" block>
+          Siguiente
+        </Button>
       </Form.Item>
-      <Form.Item name="category" label="Categoría">
-        <Select options={["Eventos","Logística"].map(v=>({value:v,label:v}))}/>
-      </Form.Item>
-      <Form.Item name="rate" label="Tarifa €/h" rules={[{required:true}]}>
-        <Input type="number"/>
-      </Form.Item>
-      <Form.Item name="duration" label="Duración" rules={[{required:true}]}>
-        <Input placeholder="4 h, 1 día…"/>
-      </Form.Item>
-      <Button type="primary" htmlType="submit">Siguiente</Button>
     </Form>
   );
 }


### PR DESCRIPTION
## Summary
- modernize UI for creating a task

## Testing
- `npm run lint` *(fails: couldn't find eslint config)*
- `npm run build` *(fails: TS7026 errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_684c69046f8883279bdc6f61cb9db833