### PR TITLE
Fix navigation link to existing route

### DIFF
--- a/src/commons/NavigationBar.tsx
+++ b/src/commons/NavigationBar.tsx
@@ -48,9 +48,9 @@ export default function NavBar() {
           <AiOutlinePlusSquare size={24} />
           <span style={styles.iconLabel}>Crear</span>
         </NavLink>
-        <NavLink to="/index" style={styles.iconLink}>
+        <NavLink to="/myProfile" style={styles.iconLink}>
           <RiDashboardLine size={24} />
-          <span style={styles.iconLabel}>Index</span>
+          <span style={styles.iconLabel}>Mi Perfil</span>
         </NavLink>
       </nav>
     </header>


### PR DESCRIPTION
## Summary
- fix broken navigation link that pointed to an undefined route

## Testing
- `npm run build` *(fails: Cannot find module 'react-icons/ai' and others)*

------
https://chatgpt.com/codex/tasks/task_e_684c640d9fd08327a250abd0e0c723c7