### PR TITLE
Add modal for task details

### DIFF
--- a/src/components/JobDetailModal.tsx
+++ b/src/components/JobDetailModal.tsx
@@ -1,0 +1,49 @@
+import { CSSProperties } from "react";
+import { Modal } from "./Modal";
+
+export interface SimpleJob {
+  title: string;
+  loc: string;
+  cat: string;
+  pay: string;
+  desc: string;
+}
+
+export function JobDetailModal({
+  job,
+  open,
+  onClose,
+}: {
+  job: SimpleJob | null;
+  open: boolean;
+  onClose: () => void;
+}) {
+  if (!job) return null;
+  return (
+    <Modal open={open} onClose={onClose}>
+      <div style={st.container}>
+        <h2 style={st.title}>{job.title}</h2>
+        <p style={st.meta}>{job.loc} · {job.cat}</p>
+        <p style={st.pay}>{job.pay}</p>
+        <p style={st.desc}>{job.desc}</p>
+        <button style={st.closeBtn} onClick={onClose}>Cerrar</button>
+      </div>
+    </Modal>
+  );
+}
+
+const st: Record<string, CSSProperties> = {
+  container: { textAlign: "center" },
+  title: { margin: "0 0 8px" },
+  meta: { color: "#666", margin: "0 0 12px" },
+  pay: { fontWeight: 600, margin: "0 0 12px" },
+  desc: { marginBottom: 20 },
+  closeBtn: {
+    background: "#0a66c2",
+    border: "none",
+    color: "white",
+    padding: "8px 24px",
+    borderRadius: 20,
+    cursor: "pointer",
+  },
+};

--- a/src/pages/Home copy/SearchPage.tsx
+++ b/src/pages/Home copy/SearchPage.tsx
@@ -1,12 +1,7 @@
 import { CSSProperties, useState } from "react";
+import { JobDetailModal, SimpleJob } from "../../components/JobDetailModal";
 
-interface Task {
-  title: string;
-  loc: string;
-  cat: string;
-  pay: string;
-  desc: string;
-}
+interface Task extends SimpleJob {}
 
 type Tab = "todo" | "personas" | "tareas";
 
@@ -144,33 +139,18 @@ export default function SearchPage() {
 
         {/* --------- SIDEBAR --------- */}
         <aside style={styles.sideCol}>
-          {selectedTask ? (
-            <div style={styles.card}>
-              <h3 style={styles.cardTitle}>{selectedTask.title}</h3>
-              <p style={styles.personSubtitle}>
-                {selectedTask.loc} · {selectedTask.pay}
-              </p>
-              <p style={styles.taskDesc}>{selectedTask.desc}</p>
-              <button
-                style={{ ...styles.connectBtn, marginTop: "12px" }}
-                onClick={() => setSelectedTask(null)}
-              >
-                Cerrar
-              </button>
-            </div>
-          ) : (
-            <div style={styles.card}>
-              <h3 style={styles.cardTitle}>Recomendaciones</h3>
-              {["Boeing","Airbus Defence & Space","GE Aerospace"].map(r=>(
-                <div key={r} style={styles.recItem}>
-                  <img src="https://via.placeholder.com/36" style={styles.avatar}/>
-                  <span>{r}</span>
-                </div>
-              ))}
-            </div>
-          )}
+          <div style={styles.card}>
+            <h3 style={styles.cardTitle}>Recomendaciones</h3>
+            {["Boeing","Airbus Defence & Space","GE Aerospace"].map(r=>(
+              <div key={r} style={styles.recItem}>
+                <img src="https://via.placeholder.com/36" style={styles.avatar}/>
+                <span>{r}</span>
+              </div>
+            ))}
+          </div>
         </aside>
       </main>
+      <JobDetailModal job={selectedTask} open={!!selectedTask} onClose={() => setSelectedTask(null)} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- improve search page by using a modal to show job details
- add JobDetailModal component

## Testing
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684c6ee431e083278b9d16648c6cbd68