### PR TITLE
feat: estructura hexagonal

### DIFF
--- a/src/application/CreateJobUseCase.ts
+++ b/src/application/CreateJobUseCase.ts
@@ -1,0 +1,10 @@
+import { Job } from '../domain/entities/Job';
+import { JobRepository } from '../domain/repositories/JobRepository';
+
+export class CreateJobUseCase {
+  constructor(private readonly repository: JobRepository) {}
+
+  execute(job: Job): Promise<Job> {
+    return this.repository.create(job);
+  }
+}

--- a/src/application/FetchJobsUseCase.ts
+++ b/src/application/FetchJobsUseCase.ts
@@ -1,0 +1,10 @@
+import { Job } from '../domain/entities/Job';
+import { JobRepository } from '../domain/repositories/JobRepository';
+
+export class FetchJobsUseCase {
+  constructor(private readonly repository: JobRepository) {}
+
+  execute(): Promise<Job[]> {
+    return this.repository.fetchAll();
+  }
+}

--- a/src/domain/entities/Job.ts
+++ b/src/domain/entities/Job.ts
@@ -1,0 +1,8 @@
+export interface Job {
+  id: string;
+  title: string;
+  description: string;
+  location: string;
+  rate: number;
+  createdAt: string;
+}

--- a/src/domain/entities/User.ts
+++ b/src/domain/entities/User.ts
@@ -1,0 +1,5 @@
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+}

--- a/src/domain/repositories/JobRepository.ts
+++ b/src/domain/repositories/JobRepository.ts
@@ -1,0 +1,6 @@
+import { Job } from '../entities/Job';
+
+export interface JobRepository {
+  create(job: Job): Promise<Job>;
+  fetchAll(): Promise<Job[]>;
+}

--- a/src/infrastructure/HttpJobRepository.ts
+++ b/src/infrastructure/HttpJobRepository.ts
@@ -1,0 +1,30 @@
+import { Job } from '../domain/entities/Job';
+import { JobRepository } from '../domain/repositories/JobRepository';
+
+export class HttpJobRepository implements JobRepository {
+  constructor(private readonly baseUrl: string) {}
+
+  async create(job: Job): Promise<Job> {
+    const response = await fetch(`${this.baseUrl}/jobs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(job),
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to create job');
+    }
+
+    return response.json();
+  }
+
+  async fetchAll(): Promise<Job[]> {
+    const response = await fetch(`${this.baseUrl}/jobs`);
+
+    if (!response.ok) {
+      throw new Error('Failed to fetch jobs');
+    }
+
+    return response.json();
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,13 @@
     "noEmit": true,
     "jsx": "react-jsx",
 
+    "baseUrl": "./",
+    "paths": {
+      "@domain/*": ["src/domain/*"],
+      "@application/*": ["src/application/*"],
+      "@infrastructure/*": ["src/infrastructure/*"]
+    },
+
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,15 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import path from 'node:path'
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@domain': path.resolve(__dirname, './src/domain'),
+      '@application': path.resolve(__dirname, './src/application'),
+      '@infrastructure': path.resolve(__dirname, './src/infrastructure'),
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- introduce domain layer with entities and repository contracts
- add application use cases and HTTP repository adapter
- configure path aliases for new hexagonal structure

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: styles is defined but never used; Unexpected any; Irregular whitespace, etc.)*
- `npm run build` *(fails: Cannot find module 'antd'; Cannot find module '../amplify_outputs.json', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68be9b7538188327bdc22774bc08475c