### PR TITLE
style: add neomorphic highlights

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,37 +82,41 @@ function App() {
 // Algunos estilos básicos (ajústalos para conseguir el efecto deseado)
 const styles = {
   appContainer: {
-    fontFamily: "Arial, sans-serif",
+    fontFamily:
+      "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif",
     minHeight: "100vh",
     display: "flex",
     flexDirection: "column",
+    background: "var(--background-color)",
+    color: "#333",
   },
-  
   contentArea: {
     flex: 1,
-    padding: "20px",
-    background: "#f0f0f3",
+    padding: "24px",
   },
   pageContainer: {
-    background: "#e0e0e0",
-    borderRadius: "16px",
-    boxShadow: "20px 20px 60px #bebebe, -20px -20px 60px #ffffff",
-    padding: "20px",
+    background: "var(--background-color)",
+    borderRadius: "12px",
+    boxShadow: "8px 8px 16px var(--shadow-dark), -8px -8px 16px var(--shadow-light)",
+    padding: "24px",
     margin: "20px auto",
     maxWidth: "800px",
   },
   footer: {
-    padding: "10px",
-    textAlign: "center" ,
-    background: "#e0e0e0",
+    padding: "16px",
+    textAlign: "center",
+    background: "#ffffff",
+    borderTop: "1px solid #dcdcdc",
+    color: "#666",
+    boxShadow: "0 -1px 2px rgba(0,0,0,0.08)",
   },
   signOutButton: {
-    background: "#e0e0e0",
-    border: "none",
+    background: "#ffffff",
+    border: "1px solid #dcdcdc",
     outline: "none",
     padding: "10px 20px",
     borderRadius: "8px",
-    boxShadow: "8px 8px 16px #bebebe, -8px -8px 16px #ffffff",
+    boxShadow: "0 1px 2px rgba(0,0,0,0.08)",
     cursor: "pointer",
   },
 };

--- a/src/commons/Footer.tsx
+++ b/src/commons/Footer.tsx
@@ -1,7 +1,7 @@
 
 export function Footer() {
   return (
-    <footer >
+    <footer style={styles.footer}>
       <div style={styles.footerContent}>
         <p>© 2025 Mi TFG. Todos los derechos reservados.</p>
         <nav style={styles.footerNav}>
@@ -21,13 +21,16 @@ export function Footer() {
 
 const styles = {
   footer: {
-    background: "#e0e0e0",
+    background: "var(--background-color)",
     padding: "20px",
-    textAlign:  "center",
-    boxShadow: "inset 0 1px 3px rgba(0,0,0,0.1)",
+    textAlign: "center",
+    color: "#666",
+    fontSize: "0.875rem",
+    boxShadow: "8px 8px 16px var(--shadow-dark), -8px -8px 16px var(--shadow-light)",
+    borderRadius: "12px 12px 0 0",
   },
   footerContent: {
-    maxWidth: "800px",
+    maxWidth: "1128px",
     margin: "0 auto",
   },
   footerNav: {
@@ -36,7 +39,7 @@ const styles = {
   footerLink: {
     margin: "0 10px",
     textDecoration: "none",
-    color: "#333",
+    color: "var(--primary-color)",
   },
   socialMedia: {
     marginTop: "10px",

--- a/src/commons/NavigationBar.tsx
+++ b/src/commons/NavigationBar.tsx
@@ -28,27 +28,76 @@ export default function NavBar() {
 
       {/* Iconos de navegación */}
       <nav style={styles.iconNav}>
-        <NavLink to="/" style={styles.iconLink} end>
+        <NavLink
+          to="/"
+          end
+          style={({ isActive }) => ({
+            ...styles.iconLink,
+            color: isActive ? "var(--primary-color)" : "#666",
+            borderBottom: isActive ? "2px solid var(--accent-color)" : "2px solid transparent",
+            boxShadow: isActive ? styles.iconLinkActive.boxShadow : styles.iconLink.boxShadow,
+          })}
+        >
           <AiFillHome size={24} />
           <span style={styles.iconLabel}>Inicio</span>
         </NavLink>
-        <NavLink to="/mispostulaciones" style={styles.iconLink}>
+        <NavLink
+          to="/mispostulaciones"
+          style={({ isActive }) => ({
+            ...styles.iconLink,
+            color: isActive ? "var(--primary-color)" : "#666",
+            borderBottom: isActive ? "2px solid var(--accent-color)" : "2px solid transparent",
+            boxShadow: isActive ? styles.iconLinkActive.boxShadow : styles.iconLink.boxShadow,
+          })}
+        >
           <MdDescription size={24} />
           <span style={styles.iconLabel}>Postulaciones</span>
         </NavLink>
-        <NavLink to="/perfil" style={styles.iconLink}>
+        <NavLink
+          to="/perfil"
+          style={({ isActive }) => ({
+            ...styles.iconLink,
+            color: isActive ? "var(--primary-color)" : "#666",
+            borderBottom: isActive ? "2px solid var(--accent-color)" : "2px solid transparent",
+            boxShadow: isActive ? styles.iconLinkActive.boxShadow : styles.iconLink.boxShadow,
+          })}
+        >
           <FaUserCircle size={24} />
           <span style={styles.iconLabel}>Perfil</span>
         </NavLink>
-        <NavLink to="/buscador" style={styles.iconLink}>
+        <NavLink
+          to="/buscador"
+          style={({ isActive }) => ({
+            ...styles.iconLink,
+            color: isActive ? "var(--primary-color)" : "#666",
+            borderBottom: isActive ? "2px solid var(--accent-color)" : "2px solid transparent",
+            boxShadow: isActive ? styles.iconLinkActive.boxShadow : styles.iconLink.boxShadow,
+          })}
+        >
           <AiOutlineSearch size={24} />
           <span style={styles.iconLabel}>Buscar</span>
         </NavLink>
-        <NavLink to="/creatrabajo" style={styles.iconLink}>
+        <NavLink
+          to="/creatrabajo"
+          style={({ isActive }) => ({
+            ...styles.iconLink,
+            color: isActive ? "var(--primary-color)" : "#666",
+            borderBottom: isActive ? "2px solid var(--accent-color)" : "2px solid transparent",
+            boxShadow: isActive ? styles.iconLinkActive.boxShadow : styles.iconLink.boxShadow,
+          })}
+        >
           <AiOutlinePlusSquare size={24} />
           <span style={styles.iconLabel}>Crear</span>
         </NavLink>
-        <NavLink to="/myProfile" style={styles.iconLink}>
+        <NavLink
+          to="/myProfile"
+          style={({ isActive }) => ({
+            ...styles.iconLink,
+            color: isActive ? "var(--primary-color)" : "#666",
+            borderBottom: isActive ? "2px solid var(--accent-color)" : "2px solid transparent",
+            boxShadow: isActive ? styles.iconLinkActive.boxShadow : styles.iconLink.boxShadow,
+          })}
+        >
           <RiDashboardLine size={24} />
           <span style={styles.iconLabel}>Mi Perfil</span>
         </NavLink>
@@ -57,57 +106,67 @@ export default function NavBar() {
   );
 }
 
+const neoShadow = "8px 8px 16px var(--shadow-dark), -8px -8px 16px var(--shadow-light)";
+const smallShadow = "4px 4px 8px var(--shadow-dark), -4px -4px 8px var(--shadow-light)";
+const insetShadow = "inset 4px 4px 8px var(--shadow-dark), inset -4px -4px 8px var(--shadow-light)";
+
 const styles: { [k: string]: React.CSSProperties } = {
   header: {
     display: "flex",
     alignItems: "center",
-    justifyContent: "center",      // <-- Centra todos los hijos
-    background: "#ffffff",
-    padding: "8px 16px",
-    boxShadow: "8px 8px 16px #ebebeb, -8px -8px 16px #ffffff",
-    gap: "32px",                    // <-- Espacio uniforme entre cada bloque
+    justifyContent: "center",
+    background: "var(--background-color)",
+    padding: "0 24px",
+    boxShadow: neoShadow,
+    gap: "32px",
+    position: "sticky",
+    top: 0,
+    zIndex: 1000,
   },
   logo: {
     fontSize: "1.25rem",
     fontWeight: "bold",
     cursor: "pointer",
-    color: "#333",
+    color: "var(--primary-color)",
   },
   searchContainer: {
     display: "flex",
     alignItems: "center",
-    background: "#ffffff",
-    borderRadius: "20px",
-    padding: "4px 12px",
-    boxShadow: "inset 4px 4px 8px #ebebeb, inset -4px -4px 8px #ffffff",
-    width: "300px",
-    marginRight: "60px"
+    background: "var(--background-color)",
+    borderRadius: "12px",
+    padding: "0 8px",
+    width: "280px",
+    boxShadow: smallShadow,
   },
   searchInput: {
     border: "none",
     outline: "none",
     flex: 1,
-    fontSize: "1rem",
+    fontSize: "0.9rem",
     background: "transparent",
   },
   iconNav: {
     display: "flex",
     gap: "24px",
     alignItems: "center",
-    // marginLeft removed para que no empuje al final
   },
   iconLink: {
     display: "flex",
-    flexDirection: "column" ,
+    flexDirection: "column",
     alignItems: "center",
     textDecoration: "none",
-    color: "#555",
-    padding: "4px",
-    borderRadius: "8px",
-    transition: "background 0.2s",
+    color: "#666",
+    padding: "4px 8px",
+    fontSize: "0.75rem",
+    borderRadius: "12px",
+    boxShadow: smallShadow,
+    background: "var(--background-color)",
+    transition: "box-shadow 0.2s",
+  },
+  iconLinkActive: {
+    boxShadow: insetShadow,
   },
   iconLabel: {
-    fontSize: "0.7rem",
     marginTop: "4px",
   },
 };

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,49 @@
+
+:root {
+  --primary-color: #0a66c2;
+  --accent-color: #ffcc00;
+  --background-color: #e0e0e0;
+  --shadow-light: #ffffff;
+  --shadow-dark: #bebebe;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  background-color: var(--background-color);
+  color: #333;
+}
+
+.app-container {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.content-area {
+  flex: 1;
+  padding: 24px;
+}
+
+a {
+  color: inherit;
+}
+
+.neo-card {
+  background: var(--background-color);
+  border-radius: 12px;
+  box-shadow: 8px 8px 16px var(--shadow-dark), -8px -8px 16px var(--shadow-light);
+}
+
+.neo-button {
+  background: var(--primary-color);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  box-shadow: 4px 4px 8px var(--shadow-dark), -4px -4px 8px var(--shadow-light);
+  cursor: pointer;
+}
+
+.neo-button:active {
+  box-shadow: inset 4px 4px 8px var(--shadow-dark), inset -4px -4px 8px var(--shadow-light);
+}

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -65,21 +65,43 @@ function HomePage() {
 }
 
 // Estilos base (neumórficos)
+const neoCard: React.CSSProperties = {
+  background: "var(--background-color)",
+  borderRadius: "12px",
+  boxShadow: "8px 8px 16px var(--shadow-dark), -8px -8px 16px var(--shadow-light)",
+};
+
+const smallCard: React.CSSProperties = {
+  background: "var(--background-color)",
+  borderRadius: "12px",
+  boxShadow: "4px 4px 8px var(--shadow-dark), -4px -4px 8px var(--shadow-light)",
+};
+
+const neoButton: React.CSSProperties = {
+  background: "var(--primary-color)",
+  color: "#ffffff",
+  border: "none",
+  borderRadius: "16px",
+  boxShadow: "4px 4px 8px var(--shadow-dark), -4px -4px 8px var(--shadow-light)",
+  cursor: "pointer",
+};
+
 const styles: { [key: string]: React.CSSProperties } = {
   container: {
     display: "flex",
     flexDirection: "column",
     minHeight: "100vh",
-    background: "#f1f1f1",
-    fontFamily: "Arial, sans-serif",
+    background: "var(--background-color)",
+    fontFamily:
+      "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif",
   },
   navbar: {
     display: "flex",
     alignItems: "center",
     justifyContent: "space-between",
-    background: "#e0e0e0",
+    background: "#ffffff",
     padding: "10px 20px",
-    boxShadow: "8px 8px 16px #bebebe, -8px -8px 16px #ffffff",
+    borderBottom: "1px solid #dcdcdc",
   },
   logo: {
     fontSize: "1.5rem",
@@ -94,10 +116,10 @@ const styles: { [key: string]: React.CSSProperties } = {
   searchInput: {
     width: "100%",
     padding: "8px 12px",
-    borderRadius: "10px",
-    border: "none",
-    boxShadow: "inset 3px 3px 5px #bebebe, inset -3px -3px 5px #ffffff",
+    borderRadius: "6px",
+    border: "1px solid #dcdcdc",
     outline: "none",
+    background: "#ffffff",
   },
   navIcons: {
     display: "flex",
@@ -107,10 +129,10 @@ const styles: { [key: string]: React.CSSProperties } = {
   navItem: {
     position: "relative",
     padding: "5px 10px",
-    borderRadius: "10px",
+    borderRadius: "6px",
     cursor: "pointer",
     fontSize: "0.9rem",
-    boxShadow: "3px 3px 5px #bebebe, -3px -3px 5px #ffffff",
+    color: "#666",
   },
   profile: {
     display: "flex",
@@ -136,9 +158,7 @@ const styles: { [key: string]: React.CSSProperties } = {
     gap: "20px",
   },
   categoriesContainer: {
-    background: "#e0e0e0",
-    borderRadius: "16px",
-    boxShadow: "20px 20px 40px #bebebe, -20px -20px 40px #ffffff",
+    ...neoCard,
     padding: "20px",
   },
   chipContainer: {
@@ -148,46 +168,32 @@ const styles: { [key: string]: React.CSSProperties } = {
     marginTop: "10px",
   },
   chip: {
-    background: "#e0e0e0",
+    ...smallCard,
     padding: "8px 12px",
-    borderRadius: "8px",
-    boxShadow: "4px 4px 8px #bebebe, -4px -4px 8px #ffffff",
     cursor: "pointer",
   },
   featuredJobs: {
-    background: "#e0e0e0",
-    borderRadius: "16px",
-    boxShadow: "20px 20px 40px #bebebe, -20px -20px 40px #ffffff",
+    ...neoCard,
     padding: "20px",
   },
   jobCard: {
-    background: "#e0e0e0",
+    ...smallCard,
     margin: "10px 0",
     padding: "10px",
-    borderRadius: "8px",
-    boxShadow: "inset 4px 4px 8px #bebebe, inset -4px -4px 8px #ffffff",
   },
   seeMoreButton: {
+    ...neoButton,
     marginTop: "10px",
     padding: "8px 16px",
-    borderRadius: "8px",
-    background: "#e0e0e0",
-    border: "none",
-    boxShadow: "4px 4px 8px #bebebe, -4px -4px 8px #ffffff",
-    cursor: "pointer",
   },
   commentsSection: {
-    background: "#e0e0e0",
-    borderRadius: "16px",
-    boxShadow: "20px 20px 40px #bebebe, -20px -20px 40px #ffffff",
+    ...neoCard,
     padding: "20px",
   },
   commentCard: {
-    background: "#e0e0e0",
+    ...smallCard,
     margin: "10px 0",
     padding: "10px",
-    borderRadius: "8px",
-    boxShadow: "4px 4px 8px #bebebe, -4px -4px 8px #ffffff",
   },
   commentText: {
     margin: 0,
@@ -199,22 +205,16 @@ const styles: { [key: string]: React.CSSProperties } = {
     gap: "20px",
   },
   topJobs: {
-    background: "#e0e0e0",
-    borderRadius: "16px",
-    boxShadow: "20px 20px 40px #bebebe, -20px -20px 40px #ffffff",
+    ...neoCard,
     padding: "20px",
   },
   sidebarCard: {
-    background: "#e0e0e0",
+    ...smallCard,
     margin: "10px 0",
     padding: "10px",
-    borderRadius: "8px",
-    boxShadow: "inset 4px 4px 8px #bebebe, inset -4px -4px 8px #ffffff",
   },
   topWorkers: {
-    background: "#e0e0e0",
-    borderRadius: "16px",
-    boxShadow: "20px 20px 40px #bebebe, -20px -20px 40px #ffffff",
+    ...neoCard,
     padding: "20px",
   },
   sectionTitle: {

--- a/src/pages/MyProfile/MyProfilePage.tsx
+++ b/src/pages/MyProfile/MyProfilePage.tsx
@@ -95,6 +95,18 @@ export function ProfilePage() {
 }
 
 // Tipado explícito de estilos
+const neoCard: CSSProperties = {
+  background: "var(--background-color)",
+  borderRadius: "12px",
+  boxShadow: "8px 8px 16px var(--shadow-dark), -8px -8px 16px var(--shadow-light)",
+};
+
+const smallCard: CSSProperties = {
+  background: "var(--background-color)",
+  borderRadius: "12px",
+  boxShadow: "4px 4px 8px var(--shadow-dark), -4px -4px 8px var(--shadow-light)",
+};
+
 const styles: Record<string, CSSProperties> = {
   container: {
     display: "flex",
@@ -102,8 +114,9 @@ const styles: Record<string, CSSProperties> = {
     gap: "20px",
     padding: "20px",
     minHeight: "100vh",
-    background: "#f1f1f1",
-    fontFamily: "Arial, sans-serif",
+    background: "var(--background-color)",
+    fontFamily:
+      "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif",
   },
   leftSection: {
     flex: 2,
@@ -118,9 +131,7 @@ const styles: Record<string, CSSProperties> = {
     gap: "20px",
   },
   profileHeader: {
-    background: "#e0e0e0",
-    borderRadius: "16px",
-    boxShadow: "20px 20px 40px #bebebe, -20px -20px 40px #ffffff",
+    ...neoCard,
     padding: "20px",
     display: "flex",
     alignItems: "center",
@@ -131,7 +142,7 @@ const styles: Record<string, CSSProperties> = {
     height: "120px",
     borderRadius: "50%",
     objectFit: "cover",
-    boxShadow: "inset 4px 4px 8px #bebebe, inset -4px -4px 8px #ffffff",
+    boxShadow: "4px 4px 8px var(--shadow-dark), -4px -4px 8px var(--shadow-light)",
   },
   profileName: {
     margin: 0,
@@ -147,9 +158,7 @@ const styles: Record<string, CSSProperties> = {
     color: "#777",
   },
   card: {
-    background: "#e0e0e0",
-    borderRadius: "16px",
-    boxShadow: "20px 20px 40px #bebebe, -20px -20px 40px #ffffff",
+    ...neoCard,
     padding: "20px",
   },
   cardTitle: {
@@ -158,14 +167,12 @@ const styles: Record<string, CSSProperties> = {
     fontSize: "1.2rem",
   },
   activityItem: {
+    ...smallCard,
     display: "flex",
     justifyContent: "space-between",
     alignItems: "center",
-    background: "#e0e0e0",
     margin: "10px 0",
     padding: "10px",
-    borderRadius: "8px",
-    boxShadow: "inset 4px 4px 8px #bebebe, inset -4px -4px 8px #ffffff",
   },
   activityDate: {
     fontSize: "0.9rem",
@@ -175,8 +182,8 @@ const styles: Record<string, CSSProperties> = {
     color: "#4A4A4A",
   },
   calendar: {
-    background: "#e0e0e0",
-    borderRadius: "8px",
+    ...neoCard,
+    padding: "10px",
   },
   calendarMonth: {
     margin: 0,
@@ -193,10 +200,8 @@ const styles: Record<string, CSSProperties> = {
     textAlign: "center",
   },
   calendarDayCell: {
-    background: "#e0e0e0",
+    ...smallCard,
     padding: "8px 0",
-    borderRadius: "8px",
-    boxShadow: "inset 2px 2px 4px #bebebe, inset -2px -2px 4px #ffffff",
     textAlign: "center",
   },
   recommendedUser: {
@@ -210,7 +215,7 @@ const styles: Record<string, CSSProperties> = {
     height: "40px",
     borderRadius: "50%",
     objectFit: "cover",
-    boxShadow: "inset 1px 1px 2px #bebebe, inset -1px -1px 2px #ffffff",
+    boxShadow: "4px 4px 8px var(--shadow-dark), -4px -4px 8px var(--shadow-light)",
   },
   recommendedUserName: {
     margin: 0,

--- a/src/pages/Tasks/TaskListPage.tsx
+++ b/src/pages/Tasks/TaskListPage.tsx
@@ -92,26 +92,46 @@ export default function TaskListPage() {
   );
 }
 
+const neoCard: React.CSSProperties = {
+  background: "var(--background-color)",
+  borderRadius: "12px",
+  boxShadow: "8px 8px 16px var(--shadow-dark), -8px -8px 16px var(--shadow-light)",
+};
+
+const smallCard: React.CSSProperties = {
+  background: "var(--background-color)",
+  borderRadius: "12px",
+  boxShadow: "4px 4px 8px var(--shadow-dark), -4px -4px 8px var(--shadow-light)",
+};
+
+const neoButton: React.CSSProperties = {
+  background: "var(--primary-color)",
+  color: "#ffffff",
+  border: "none",
+  borderRadius: "8px",
+  boxShadow: "4px 4px 8px var(--shadow-dark), -4px -4px 8px var(--shadow-light)",
+  cursor: "pointer",
+};
+
 const styles: Record<string, React.CSSProperties> = {
   container: {
     padding: "20px",
+    background: "var(--background-color)",
+    fontFamily:
+      "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif",
   },
   title: {
     textAlign: "center",
   },
   taskCard: {
-    background: "#e0e0e0",
+    ...smallCard,
     padding: "16px",
-    borderRadius: "8px",
     marginBottom: "10px",
-    boxShadow: "8px 8px 16px #bebebe, -8px -8px 16px #ffffff",
   },
   applyButton: {
+    ...neoButton,
     marginTop: "8px",
     padding: "8px 12px",
-    border: "none",
-    borderRadius: "6px",
-    cursor: "pointer",
   },
   modalBackdrop: {
     position: "fixed",
@@ -125,10 +145,8 @@ const styles: Record<string, React.CSSProperties> = {
     justifyContent: "center",
   },
   form: {
-    background: "#fff",
+    ...neoCard,
     padding: "20px",
-    borderRadius: "8px",
-    boxShadow: "8px 8px 16px #bebebe, -8px -8px 16px #ffffff",
     minWidth: "300px",
   },
   formTitle: {
@@ -156,19 +174,16 @@ const styles: Record<string, React.CSSProperties> = {
     gap: "8px",
   },
   cancelButton: {
-    background: "#ccc",
-    border: "none",
+    background: "transparent",
+    border: "1px solid #666",
     padding: "8px 12px",
     borderRadius: "6px",
     cursor: "pointer",
+    color: "#666",
   },
   submitButton: {
-    background: "#4caf50",
-    color: "white",
-    border: "none",
+    ...neoButton,
     padding: "8px 12px",
-    borderRadius: "6px",
-    cursor: "pointer",
   },
 };
 


### PR DESCRIPTION
## Summary
- define global neomorphic variables and helpers
- restyle navigation, footer, and pages with soft shadows and accent glow
- preserve LinkedIn-like palette while adding Pokémon-style highlights

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68beb58011888327a2f8c80875219f8a